### PR TITLE
Activity stopped over liked page -  bug fixed

### DIFF
--- a/app/src/main/java/com/example/gautamdhariharan/semadio/fragment/likedFragment.java
+++ b/app/src/main/java/com/example/gautamdhariharan/semadio/fragment/likedFragment.java
@@ -101,12 +101,6 @@ public class likedFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (context instanceof OnFragmentInteractionListener) {
-            mListener = (OnFragmentInteractionListener) context;
-        } else {
-            throw new RuntimeException(context.toString()
-                    + " must implement OnFragmentInteractionListener");
-        }
     }
 
     @Override


### PR DESCRIPTION
Fragment interaction is not required for now. Therefore, the deleted code was redundant.